### PR TITLE
fix: adding identity and keycloak for web-modeler copose file - 8.6

### DIFF
--- a/.github/workflows/docker-compose-test-e2e-full-setup.yaml
+++ b/.github/workflows/docker-compose-test-e2e-full-setup.yaml
@@ -88,7 +88,6 @@ jobs:
             e2e-test-enabled: false
           - name: Camunda 8.6 - Web Modeler Standalone
             camunda-version: "8.6"
-            deps-compose-args: "--profile identity"
             main-compose-args: "-f docker-compose-web-modeler.yaml"
             e2e-test-enabled: false
           # Camunda Alpha

--- a/docker-compose/versions/camunda-8.6/docker-compose-web-modeler.yaml
+++ b/docker-compose/versions/camunda-8.6/docker-compose-web-modeler.yaml
@@ -1,34 +1,32 @@
-# Docker Compose file for Web Modeler Self-Managed. This file is not intended to be used stand-alone.
-# Use it in combination with docker-compose.yaml:
-#
-#    docker-compose -f docker-compose.yaml -f docker-compose-web-modeler.yaml up -d
-#
+# Docker Compose file for Web Modeler Self-Managed. This file can be used stand-alone. It will install Web Modeler Dependencies:
+# 1. identity
+# 2. keycloak
 # Note: this file is using Mailpit to simulate a mail server
 
 services:
 
-  modeler-db:
-    container_name: modeler-db
+  web-modeler-db:
+    container_name: web-modeler-db
     image: postgres:${POSTGRES_VERSION}
     healthcheck:
-      test: pg_isready -d modeler-db -U modeler-db-user
+      test: pg_isready -d web-modeler-db -U web-modeler-db-user
       interval: 5s
       timeout: 15s
       retries: 30
     environment:
-      POSTGRES_DB: modeler-db
-      POSTGRES_USER: modeler-db-user
-      POSTGRES_PASSWORD: modeler-db-password
+      POSTGRES_DB: web-modeler-db
+      POSTGRES_USER: web-modeler-db-user
+      POSTGRES_PASSWORD: web-modeler-db-password
     networks:
-      - modeler
+      - web-modeler
     volumes:
       - postgres-web:/var/lib/postgresql/data
     profiles:
       - ''
       - web-modeler-standalone
 
-  modeler-websockets:
-    container_name: modeler-websockets
+  web-modeler-websockets:
+    container_name: web-modeler-websockets
     image: camunda/web-modeler-websockets:${CAMUNDA_WEB_MODELER_VERSION}
     ports:
       - "8060:8060"
@@ -40,20 +38,20 @@ services:
     environment:
       APP_NAME: "Web Modeler Self-Managed WebSockets"
       APP_DEBUG: "true"
-      PUSHER_APP_ID: modeler-app
-      PUSHER_APP_KEY: modeler-app-key
-      PUSHER_APP_SECRET: modeler-app-secret
+      PUSHER_APP_ID: web-modeler-app
+      PUSHER_APP_KEY: web-modeler-app-key
+      PUSHER_APP_SECRET: web-modeler-app-secret
     networks:
-      - modeler
+      - web-modeler
     profiles:
       - ''
       - web-modeler-standalone
 
-  modeler-mailpit:
+  mailpit:
     # If you want to use your own SMTP server, you can remove this container
     # and configure RESTAPI_MAIL_HOST, RESTAPI_MAIL_PORT, REST_API_MAIL_USER,
-    # REST_API_MAIL_PASSWORD and RESTAPI_MAIL_ENABLE_TLS in modeler-restapi
-    container_name: modeler-mailpit
+    # REST_API_MAIL_PASSWORD and RESTAPI_MAIL_ENABLE_TLS in web-modeler-restapi
+    container_name: web-modeler-mailpit
     image: axllent/mailpit:${MAILPIT_VERSION}
     ports:
       - "1025:1025"
@@ -62,21 +60,23 @@ services:
       test: /usr/bin/nc -v localhost 1025
       interval: 30s
     networks:
-      - modeler
+      - web-modeler
     profiles:
       - ''
       - web-modeler-standalone
 
   # Modeler containers
-  modeler-restapi:
-    container_name: modeler-restapi
+  web-modeler-restapi:
+    container_name: web-modeler-restapi
     image: camunda/web-modeler-restapi:${CAMUNDA_WEB_MODELER_VERSION}
     command: /bin/sh -c "java $JAVA_OPTIONS org.springframework.boot.loader.JarLauncher"
     depends_on:
-      modeler-db:
+      web-modeler-db:
         condition: service_healthy
-      modeler-mailpit:
+      mailpit:
         condition: service_started
+      identity:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8091/health/readiness"]
       interval: 5s
@@ -86,36 +86,36 @@ services:
       JAVA_OPTIONS: -Xmx128m
       LOGGING_LEVEL_IO_CAMUNDA_MODELER: DEBUG
       CAMUNDA_IDENTITY_BASEURL: http://identity:8084/
-      SPRING_DATASOURCE_URL: jdbc:postgresql://modeler-db:5432/modeler-db
-      SPRING_DATASOURCE_USERNAME: modeler-db-user
-      SPRING_DATASOURCE_PASSWORD: modeler-db-password
+      SPRING_DATASOURCE_URL: jdbc:postgresql://web-modeler-db:5432/web-modeler-db
+      SPRING_DATASOURCE_USERNAME: web-modeler-db-user
+      SPRING_DATASOURCE_PASSWORD: web-modeler-db-password
       SPRING_PROFILES_INCLUDE: default-logging
-      RESTAPI_PUSHER_HOST: modeler-websockets
+      RESTAPI_PUSHER_HOST: web-modeler-websockets
       RESTAPI_PUSHER_PORT: "8060"
-      RESTAPI_PUSHER_APP_ID: modeler-app
-      RESTAPI_PUSHER_KEY: modeler-app-key
-      RESTAPI_PUSHER_SECRET: modeler-app-secret
+      RESTAPI_PUSHER_APP_ID: web-modeler-app
+      RESTAPI_PUSHER_KEY: web-modeler-app-key
+      RESTAPI_PUSHER_SECRET: web-modeler-app-secret
       RESTAPI_OAUTH2_TOKEN_ISSUER: http://${KEYCLOAK_HOST}:18080/auth/realms/camunda-platform
       RESTAPI_OAUTH2_TOKEN_ISSUER_BACKEND_URL: http://keycloak:18080/auth/realms/camunda-platform
       RESTAPI_SERVER_URL: http://localhost:8070
-      RESTAPI_MAIL_HOST: modeler-mailpit
+      RESTAPI_MAIL_HOST: mailpit
       RESTAPI_MAIL_PORT: 1025
       RESTAPI_MAIL_ENABLE_TLS: "false"
       RESTAPI_MAIL_FROM_ADDRESS: "noreply@example.com"
     networks:
-      - modeler
+      - web-modeler
       - camunda-platform
     profiles:
       - ''
-      - web-modeler-standalone
+      - web-modeler
 
-  modeler-webapp:
-    container_name: modeler-webapp
+  web-modeler-webapp:
+    container_name: web-modeler-webapp
     image: camunda/web-modeler-webapp:${CAMUNDA_WEB_MODELER_VERSION}
     ports:
       - "8070:8070"
     depends_on:
-      modeler-restapi:
+      web-modeler-restapi:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8071/health/readiness"]
@@ -123,18 +123,18 @@ services:
       timeout: 15s
       retries: 30
     environment:
-      RESTAPI_HOST: modeler-restapi
+      RESTAPI_HOST: web-modeler-restapi
       SERVER_HTTPS_ONLY: "false"
       SERVER_URL: http://localhost:8070
-      PUSHER_APP_ID: modeler-app
-      PUSHER_KEY: modeler-app-key
-      PUSHER_SECRET: modeler-app-secret
-      PUSHER_HOST: modeler-websockets
+      PUSHER_APP_ID: web-modeler-app
+      PUSHER_KEY: web-modeler-app-key
+      PUSHER_SECRET: web-modeler-app-secret
+      PUSHER_HOST: web-modeler-websockets
       PUSHER_PORT: "8060"
       CLIENT_PUSHER_HOST: localhost
       CLIENT_PUSHER_PORT: "8060"
       CLIENT_PUSHER_FORCE_TLS: "false"
-      CLIENT_PUSHER_KEY: modeler-app-key
+      CLIENT_PUSHER_KEY: web-modeler-app-key
       OAUTH2_CLIENT_ID: web-modeler
       OAUTH2_JWKS_URL: http://keycloak:18080/auth/realms/camunda-platform/protocol/openid-connect/certs
       OAUTH2_TOKEN_AUDIENCE: web-modeler
@@ -142,15 +142,145 @@ services:
       IDENTITY_BASE_URL: http://identity:8084/
       PLAY_ENABLED: "true"
     networks:
-      - modeler
+      - web-modeler
       - camunda-platform
     profiles:
       - ''
       - web-modeler-standalone
 
+  ## Dependencies: identity, keycloak, postgres for keycloak
+  identity: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#identity
+    container_name: identity
+    image: camunda/identity:${CAMUNDA_IDENTITY_VERSION}
+    ports:
+      - "8084:8084"
+    environment: # https://docs.camunda.io/docs/self-managed/identity/deployment/configuration-variables/
+      SERVER_PORT: 8084
+      IDENTITY_RETRY_DELAY_SECONDS: 30
+      IDENTITY_URL: http://${HOST}:8084
+      KEYCLOAK_URL: http://keycloak:18080/auth
+      IDENTITY_AUTH_PROVIDER_ISSUER_URL: http://${KEYCLOAK_HOST}:18080/auth/realms/camunda-platform
+      IDENTITY_AUTH_PROVIDER_BACKEND_URL: http://keycloak:18080/auth/realms/camunda-platform
+      IDENTITY_DATABASE_HOST: postgres
+      IDENTITY_DATABASE_PORT: 5432
+      IDENTITY_DATABASE_NAME: bitnami_keycloak
+      IDENTITY_DATABASE_USERNAME: bn_keycloak
+      IDENTITY_DATABASE_PASSWORD: "#3]O?4RGj)DE7Z!9SA5"
+      KEYCLOAK_INIT_OPERATE_SECRET: XALaRPl5qwTEItdwCMiPS62nVpKs7dL7
+      KEYCLOAK_INIT_OPERATE_ROOT_URL: http://${HOST}:8081
+      KEYCLOAK_INIT_TASKLIST_SECRET: XALaRPl5qwTEItdwCMiPS62nVpKs7dL7
+      KEYCLOAK_INIT_TASKLIST_ROOT_URL: http://${HOST}:8082
+      KEYCLOAK_INIT_OPTIMIZE_SECRET: XALaRPl5qwTEItdwCMiPS62nVpKs7dL7
+      KEYCLOAK_INIT_OPTIMIZE_ROOT_URL: http://${HOST}:8083
+      KEYCLOAK_INIT_WEBMODELER_ROOT_URL: http://${HOST}:8070
+      KEYCLOAK_INIT_CONNECTORS_SECRET: XALaRPl5qwTEItdwCMiPS62nVpKs7dL7
+      KEYCLOAK_INIT_CONNECTORS_ROOT_URL: http://${HOST}:8085
+      KEYCLOAK_INIT_ZEEBE_NAME: zeebe
+      KEYCLOAK_USERS_0_USERNAME: "demo"
+      KEYCLOAK_USERS_0_PASSWORD: "demo"
+      KEYCLOAK_USERS_0_FIRST_NAME: "demo"
+      KEYCLOAK_USERS_0_EMAIL: "demo@acme.com"
+      KEYCLOAK_USERS_0_ROLES_0: "Identity"
+      KEYCLOAK_USERS_0_ROLES_1: "Optimize"
+      KEYCLOAK_USERS_0_ROLES_2: "Operate"
+      KEYCLOAK_USERS_0_ROLES_3: "Tasklist"
+      KEYCLOAK_USERS_0_ROLES_4: "Web Modeler"
+      KEYCLOAK_USERS_0_ROLES_5: "Web Modeler Admin"
+      KEYCLOAK_USERS_0_ROLES_6: "Zeebe"
+      KEYCLOAK_CLIENTS_0_NAME: zeebe
+      KEYCLOAK_CLIENTS_0_ID: ${ZEEBE_CLIENT_ID}
+      KEYCLOAK_CLIENTS_0_SECRET: ${ZEEBE_CLIENT_SECRET}
+      KEYCLOAK_CLIENTS_0_TYPE: M2M
+      KEYCLOAK_CLIENTS_0_PERMISSIONS_0_RESOURCE_SERVER_ID: zeebe-api
+      KEYCLOAK_CLIENTS_0_PERMISSIONS_0_DEFINITION: write:*
+      KEYCLOAK_CLIENTS_0_PERMISSIONS_1_RESOURCE_SERVER_ID: operate-api
+      KEYCLOAK_CLIENTS_0_PERMISSIONS_1_DEFINITION: write:*
+      KEYCLOAK_CLIENTS_0_PERMISSIONS_2_RESOURCE_SERVER_ID: tasklist-api
+      KEYCLOAK_CLIENTS_0_PERMISSIONS_2_DEFINITION: write:*
+      KEYCLOAK_CLIENTS_0_PERMISSIONS_3_RESOURCE_SERVER_ID: optimize-api
+      KEYCLOAK_CLIENTS_0_PERMISSIONS_3_DEFINITION: write:*
+      KEYCLOAK_CLIENTS_0_PERMISSIONS_4_RESOURCE_SERVER_ID: tasklist-api
+      KEYCLOAK_CLIENTS_0_PERMISSIONS_4_DEFINITION: read:*
+      KEYCLOAK_CLIENTS_0_PERMISSIONS_5_RESOURCE_SERVER_ID: operate-api
+      KEYCLOAK_CLIENTS_0_PERMISSIONS_5_DEFINITION: read:*
+      MULTITENANCY_ENABLED: ${MULTI_TENANCY_ENABLED}
+      RESOURCE_PERMISSIONS_ENABLED: ${RESOURCE_AUTHORIZATIONS_ENABLED}
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--tries=1", "--spider", "http://localhost:8082/actuator/health"]
+      interval: 5s
+      timeout: 15s
+      retries: 30
+      start_period: 60s
+    restart: on-failure
+    volumes:
+      - keycloak-theme:/app/keycloak-theme
+    networks:
+      - camunda-platform
+      - identity-network
+    depends_on:
+      keycloak:
+        condition: service_healthy
+    profiles:
+      - ''
+      - identity
+
+  postgres: # https://hub.docker.com/_/postgres
+    container_name: postgres
+    image: postgres:${POSTGRES_VERSION}
+    environment:
+      POSTGRES_DB: bitnami_keycloak
+      POSTGRES_USER: bn_keycloak
+      POSTGRES_PASSWORD: "#3]O?4RGj)DE7Z!9SA5"
+    restart: on-failure
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - postgres:/var/lib/postgresql/data
+    networks:
+      - identity-network
+    profiles:
+      - ''
+      - identity
+
+  keycloak: # https://hub.docker.com/r/bitnami/keycloak
+    container_name: keycloak
+    image: bitnami/keycloak:${KEYCLOAK_SERVER_VERSION}
+    volumes:
+      - keycloak-theme:/opt/bitnami/keycloak/themes/identity
+    ports:
+      - "18080:18080"
+    environment:
+      KEYCLOAK_HTTP_PORT: 18080
+      KEYCLOAK_HTTP_RELATIVE_PATH: /auth
+      KEYCLOAK_DATABASE_HOST: postgres
+      KEYCLOAK_DATABASE_PASSWORD: "#3]O?4RGj)DE7Z!9SA5"
+      KEYCLOAK_ADMIN_USER: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
+    restart: on-failure
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:18080/auth"]
+      interval: 30s
+      timeout: 15s
+      retries: 5
+      start_period: 30s
+    networks:
+      - camunda-platform
+      - identity-network
+    depends_on:
+      - postgres
+    profiles:
+      - ''
+      - identity
+
 networks:
   camunda-platform:
-  modeler:
+  identity-network:
+  web-modeler:
 
 volumes:
+  postgres:
   postgres-web:
+  keycloak-theme:

--- a/docker-compose/versions/camunda-8.6/docker-compose-web-modeler.yaml
+++ b/docker-compose/versions/camunda-8.6/docker-compose-web-modeler.yaml
@@ -7,6 +7,7 @@ services:
 
   web-modeler-db:
     container_name: web-modeler-db
+
     image: postgres:${POSTGRES_VERSION}
     healthcheck:
       test: pg_isready -d web-modeler-db -U web-modeler-db-user


### PR DESCRIPTION
related: https://github.com/camunda/camunda-distributions/issues/83
I have changed 3 things in this PR:

1. The comment at the top of the file
2. renamed `modeler` to `web-modeler` to align with the same naming in the main compose file
3. added identity and keycloak

There are many things I want to improve in this file, but in its current state, it is working. I just copied over the identity and keycloak for the main compose file. I will make further improvements in subsequent PRs.