### PR TITLE
fix: remove deps from web-modeler standalone in ci - 8.6

### DIFF
--- a/.github/workflows/docker-compose-test-e2e-full-setup.yaml
+++ b/.github/workflows/docker-compose-test-e2e-full-setup.yaml
@@ -88,7 +88,6 @@ jobs:
             e2e-test-enabled: false
           - name: Camunda 8.6 - Web Modeler Standalone
             camunda-version: "8.6"
-            deps-compose-args: "--profile identity"
             main-compose-args: "-f docker-compose-web-modeler.yaml"
             e2e-test-enabled: false
           # Camunda Alpha

--- a/docker-compose/versions/camunda-8.6/docker-compose-web-modeler.yaml
+++ b/docker-compose/versions/camunda-8.6/docker-compose-web-modeler.yaml
@@ -5,10 +5,10 @@
 #
 # Note: this file is using Mailpit to simulate a mail server
 
-
 services:
 
   modeler-db:
+
     container_name: modeler-db
     image: postgres:${POSTGRES_VERSION}
     healthcheck:

--- a/docker-compose/versions/camunda-8.6/docker-compose-web-modeler.yaml
+++ b/docker-compose/versions/camunda-8.6/docker-compose-web-modeler.yaml
@@ -5,6 +5,7 @@
 #
 # Note: this file is using Mailpit to simulate a mail server
 
+
 services:
 
   modeler-db:


### PR DESCRIPTION
related: #83 
Removing the need to install dep components for standalone web-modeler compose file in 8.6.
This PR depends on: https://github.com/camunda/camunda-distributions/pull/95