### PR TITLE
fix: add Zeebe env parameters required to have REST api working with MT

### DIFF
--- a/docker-compose/versions/camunda-8.5/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.5/docker-compose.yaml
@@ -33,6 +33,10 @@ services:
       # allow running with low disk space
       - ZEEBE_BROKER_DATA_DISKUSAGECOMMANDWATERMARK=0.998
       - ZEEBE_BROKER_DATA_DISKUSAGEREPLICATIONWATERMARK=0.999
+      - CAMUNDA_IDENTITY_ISSUERBACKENDURL=http://keycloak:18080/auth/realms/camunda-platform
+      - CAMUNDA_IDENTITY_BASEURL=http://identity:8084
+      - CAMUNDA_IDENTITY_AUDIENCE=zeebe-api
+      - SPRING_PROFILES_ACTIVE=identity-auth
       - "JAVA_TOOL_OPTIONS=-Xms512m -Xmx512m"
     restart: always
     healthcheck:

--- a/docker-compose/versions/camunda-8.6/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.6/docker-compose.yaml
@@ -32,6 +32,10 @@ services:
       - ZEEBE_BROKER_DATA_DISKUSAGECOMMANDWATERMARK=0.998
       - ZEEBE_BROKER_DATA_DISKUSAGEREPLICATIONWATERMARK=0.999
       - CAMUNDA_DATABASE_URL=http://elasticsearch:9200
+      - CAMUNDA_IDENTITY_ISSUERBACKENDURL=http://keycloak:18080/auth/realms/camunda-platform
+      - CAMUNDA_IDENTITY_BASEURL=http://identity:8084
+      - CAMUNDA_IDENTITY_AUDIENCE=zeebe-api
+      - SPRING_PROFILES_ACTIVE=identity-auth
       - "JAVA_TOOL_OPTIONS=-Xms512m -Xmx512m"
     restart: always
     healthcheck:

--- a/docker-compose/versions/camunda-alpha/docker-compose.yaml
+++ b/docker-compose/versions/camunda-alpha/docker-compose.yaml
@@ -32,6 +32,10 @@ services:
       - ZEEBE_BROKER_DATA_DISKUSAGECOMMANDWATERMARK=0.998
       - ZEEBE_BROKER_DATA_DISKUSAGEREPLICATIONWATERMARK=0.999
       - CAMUNDA_DATABASE_URL=http://elasticsearch:9200
+      - CAMUNDA_IDENTITY_ISSUERBACKENDURL=http://keycloak:18080/auth/realms/camunda-platform
+      - CAMUNDA_IDENTITY_BASEURL=http://identity:8084
+      - CAMUNDA_IDENTITY_AUDIENCE=zeebe-api
+      - SPRING_PROFILES_ACTIVE=identity-auth
       - "JAVA_TOOL_OPTIONS=-Xms512m -Xmx512m"
     restart: always
     healthcheck:


### PR DESCRIPTION
[Slack discussion](https://camunda.slack.com/archives/C043W5V88M7/p1742290020422559)

This changes are required to have Zeebe REST API working with multiTenancy enabled.
This is aligned with helm chart setup https://github.com/camunda/camunda-platform-helm/blob/0f1a15e76f4626bfcccae3e37c4b051b2147a971/charts/camunda-platform-alpha/templates/zeebe-gateway/configmap.yaml#L59-L64