### PR TITLE
fix: add 8.7 to release workflow matrix

### DIFF
--- a/.github/workflows/docker-compose-release.yaml
+++ b/.github/workflows/docker-compose-release.yaml
@@ -59,6 +59,8 @@ jobs:
             camunda-version: 8.5
           - name: Camunda 8.6
             camunda-version: 8.6
+          - name: Camunda 8.7
+            camunda-version: 8.7
           - name: Camunda Alpha
             camunda-version: alpha
         exclude: ${{ fromJson(needs.init.outputs.unchanged-versions) }}


### PR DESCRIPTION
I forgot to add 8.7 to the matrix in the release workflow.