### PR TITLE
refactor(docker-compose): remove kibana from all versions

### DIFF
--- a/docker-compose/versions/camunda-8.3/docker-compose-core.yaml
+++ b/docker-compose/versions/camunda-8.3/docker-compose-core.yaml
@@ -140,24 +140,9 @@ services:
     networks:
       - camunda-platform
 
-  kibana:
-    image: docker.elastic.co/kibana/kibana:${ELASTIC_VERSION}
-    container_name: kibana
-    ports:
-      - 5601:5601
-    volumes:
-      - kibana:/usr/share/kibana/data
-    networks:
-      - camunda-platform
-    depends_on:
-      - elasticsearch
-    profiles:
-      - kibana
-
 volumes:
   zeebe:
   elastic:
-  kibana:
 
 networks:
   camunda-platform:

--- a/docker-compose/versions/camunda-8.3/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.3/docker-compose.yaml
@@ -496,26 +496,11 @@ services:
       - ''
       - web-modeler-standalone
 
-  kibana:
-    image: docker.elastic.co/kibana/kibana:${ELASTIC_VERSION}
-    container_name: kibana
-    ports:
-      - 5601:5601
-    volumes:
-      - kibana:/usr/share/kibana/data
-    networks:
-      - camunda-platform
-    depends_on:
-      - elasticsearch
-    profiles:
-      - kibana
-
 volumes:
   zeebe:
   elastic:
   postgres:
   keycloak-theme:
-  kibana:
 
 networks:
   # Note there are two bridge networks: One for Camunda Platform and one for Identity.

--- a/docker-compose/versions/camunda-8.4/docker-compose-core.yaml
+++ b/docker-compose/versions/camunda-8.4/docker-compose-core.yaml
@@ -143,24 +143,9 @@ services:
     networks:
       - camunda-platform
 
-  kibana:
-    image: docker.elastic.co/kibana/kibana:${ELASTIC_VERSION}
-    container_name: kibana
-    ports:
-      - 5601:5601
-    volumes:
-      - kibana:/usr/share/kibana/data
-    networks:
-      - camunda-platform
-    depends_on:
-      - elasticsearch
-    profiles:
-      - kibana
-
 volumes:
   zeebe:
   elastic:
-  kibana:
 
 networks:
   camunda-platform:

--- a/docker-compose/versions/camunda-8.4/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.4/docker-compose.yaml
@@ -514,26 +514,11 @@ services:
       - ''
       - web-modeler-standalone
 
-  kibana:
-    image: docker.elastic.co/kibana/kibana:${ELASTIC_VERSION}
-    container_name: kibana
-    ports:
-      - 5601:5601
-    volumes:
-      - kibana:/usr/share/kibana/data
-    networks:
-      - camunda-platform
-    depends_on:
-      - elasticsearch
-    profiles:
-      - kibana
-
 volumes:
   zeebe:
   elastic:
   postgres:
   keycloak-theme:
-  kibana:
   operate_tmp:
   tasklist_tmp:
   postgres-web:

--- a/docker-compose/versions/camunda-8.5/docker-compose-core.yaml
+++ b/docker-compose/versions/camunda-8.5/docker-compose-core.yaml
@@ -144,24 +144,9 @@ services:
     networks:
       - camunda-platform
 
-  kibana:
-    image: docker.elastic.co/kibana/kibana:${ELASTIC_VERSION}
-    container_name: kibana
-    ports:
-      - 5601:5601
-    volumes:
-      - kibana:/usr/share/kibana/data
-    networks:
-      - camunda-platform
-    depends_on:
-      - elasticsearch
-    profiles:
-      - kibana
-
 volumes:
   zeebe:
   elastic:
-  kibana:
 
 networks:
   camunda-platform:

--- a/docker-compose/versions/camunda-8.5/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.5/docker-compose.yaml
@@ -528,26 +528,11 @@ services:
       - ''
       - web-modeler-standalone
 
-  kibana:
-    image: docker.elastic.co/kibana/kibana:${ELASTIC_VERSION}
-    container_name: kibana
-    ports:
-      - 5601:5601
-    volumes:
-      - kibana:/usr/share/kibana/data
-    networks:
-      - camunda-platform
-    depends_on:
-      - elasticsearch
-    profiles:
-      - kibana
-
 volumes:
   zeebe:
   elastic:
   postgres:
   keycloak-theme:
-  kibana:
   operate_tmp:
   tasklist_tmp:
   postgres-web:

--- a/docker-compose/versions/camunda-8.6/docker-compose-core.yaml
+++ b/docker-compose/versions/camunda-8.6/docker-compose-core.yaml
@@ -147,24 +147,9 @@ services:
     networks:
       - camunda-platform
 
-  kibana:
-    image: docker.elastic.co/kibana/kibana:${ELASTIC_VERSION}
-    container_name: kibana
-    ports:
-      - 5601:5601
-    volumes:
-      - kibana:/usr/share/kibana/data
-    networks:
-      - camunda-platform
-    depends_on:
-      - elasticsearch
-    profiles:
-      - kibana
-
 volumes:
   zeebe:
   elastic:
-  kibana:
 
 networks:
   camunda-platform:

--- a/docker-compose/versions/camunda-8.6/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.6/docker-compose.yaml
@@ -543,26 +543,11 @@ services:
       - ''
       - web-modeler
 
-  kibana:
-    image: docker.elastic.co/kibana/kibana:${ELASTIC_VERSION}
-    container_name: kibana
-    ports:
-      - 5601:5601
-    volumes:
-      - kibana:/usr/share/kibana/data
-    networks:
-      - camunda-platform
-    depends_on:
-      - elasticsearch
-    profiles:
-      - kibana
-
 volumes:
   zeebe:
   elastic:
   postgres:
   keycloak-theme:
-  kibana:
   operate_tmp:
   tasklist_tmp:
   postgres-web:

--- a/docker-compose/versions/camunda-8.7/docker-compose-core.yaml
+++ b/docker-compose/versions/camunda-8.7/docker-compose-core.yaml
@@ -146,24 +146,9 @@ services:
     networks:
       - camunda-platform
 
-  kibana:
-    image: docker.elastic.co/kibana/kibana:${ELASTIC_VERSION}
-    container_name: kibana
-    ports:
-      - 5601:5601
-    volumes:
-      - kibana:/usr/share/kibana/data
-    networks:
-      - camunda-platform
-    depends_on:
-      - elasticsearch
-    profiles:
-      - kibana
-
 volumes:
   zeebe:
   elastic:
-  kibana:
 
 networks:
   camunda-platform:

--- a/docker-compose/versions/camunda-8.7/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.7/docker-compose.yaml
@@ -561,26 +561,11 @@ services:
       - ''
       - web-modeler
 
-  kibana:
-    image: docker.elastic.co/kibana/kibana:${ELASTIC_VERSION}
-    container_name: kibana
-    ports:
-      - 5601:5601
-    volumes:
-      - kibana:/usr/share/kibana/data
-    networks:
-      - camunda-platform
-    depends_on:
-      - elasticsearch
-    profiles:
-      - kibana
-
 volumes:
   zeebe:
   elastic:
   postgres:
   keycloak-theme:
-  kibana:
   operate_tmp:
   tasklist_tmp:
   postgres-web:


### PR DESCRIPTION
As discussed in https://github.com/camunda/camunda-distributions/issues/110

We remove [Kibana](https://github.com/camunda/camunda-distributions/blob/9055e1eacc16491753afc899f2725c51d2a14d92/docker-compose/versions/camunda-8.6/docker-compose.yaml#L546) from Docker Compose as it's not a necessary part to run Camunda stack.

Users can install it using their own methods.

The change will affect all versions from 8.3 to 8.7.