### PR TITLE
refactor(docker-compose): remove profiles from all versions

### DIFF
--- a/docker-compose/versions/camunda-8.3/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.3/docker-compose.yaml
@@ -45,9 +45,6 @@ services:
     depends_on:
       - elasticsearch
       - identity
-    profiles:
-      - ''
-      - orchestration
 
   operate: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#operate
     image: camunda/operate:${CAMUNDA_PLATFORM_VERSION}
@@ -88,9 +85,6 @@ services:
       - zeebe
       - identity
       - elasticsearch
-    profiles:
-      - ''
-      - orchestration
 
   tasklist: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#tasklist
     image: camunda/tasklist:${CAMUNDA_PLATFORM_VERSION}
@@ -134,9 +128,6 @@ services:
         condition: service_healthy
       identity:
         condition: service_healthy
-    profiles:
-      - ''
-      - orchestration
 
   connectors: # https://docs.camunda.io/docs/components/integration-framework/connectors/out-of-the-box-connectors/available-connectors-overview/
     image: camunda/connectors-bundle:${CAMUNDA_CONNECTORS_VERSION}
@@ -170,9 +161,6 @@ services:
       - zeebe
       - operate
       - identity
-    profiles:
-      - ''
-      - orchestration
 
   optimize: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#optimize
     image: camunda/optimize:${CAMUNDA_OPTIMIZE_VERSION}
@@ -208,9 +196,6 @@ services:
     depends_on:
       - identity
       - elasticsearch
-    profiles:
-      - ''
-      - orchestration
 
   identity: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#identity
     container_name: identity
@@ -268,9 +253,6 @@ services:
     depends_on:
       keycloak:
         condition: service_healthy
-    profiles:
-      - ''
-      - identity
 
   postgres: # https://hub.docker.com/_/postgres
     container_name: postgres
@@ -289,9 +271,6 @@ services:
       - postgres:/var/lib/postgresql/data
     networks:
       - identity-network
-    profiles:
-      - ''
-      - identity
 
   keycloak: # https://hub.docker.com/r/bitnami/keycloak
     container_name: keycloak
@@ -318,9 +297,6 @@ services:
       - identity-network
     depends_on:
       - postgres
-    profiles:
-      - ''
-      - identity
 
   elasticsearch: # https://hub.docker.com/_/elasticsearch
     image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION}
@@ -349,9 +325,6 @@ services:
       - elastic:/usr/share/elasticsearch/data
     networks:
       - camunda-platform
-    profiles:
-      - ''
-      - orchestration
 
   modeler-db:
     container_name: modeler-db
@@ -367,9 +340,6 @@ services:
       POSTGRES_PASSWORD: modeler-db-password
     networks:
       - modeler
-    profiles:
-      - ''
-      - web-modeler-standalone
 
   modeler-websockets:
     container_name: modeler-websockets
@@ -389,9 +359,6 @@ services:
       PUSHER_APP_SECRET: modeler-app-secret
     networks:
       - modeler
-    profiles:
-      - ''
-      - web-modeler-standalone
 
   mailpit:
     # If you want to use your own SMTP server, you can remove this container
@@ -407,9 +374,6 @@ services:
       interval: 30s
     networks:
       - modeler
-    profiles:
-      - ''
-      - web-modeler-standalone
 
   # Modeler containers
   modeler-restapi:
@@ -451,9 +415,6 @@ services:
     networks:
       - modeler
       - camunda-platform
-    profiles:
-      - ''
-      - web-modeler-standalone
 
   modeler-webapp:
     container_name: modeler-webapp
@@ -492,9 +453,6 @@ services:
     networks:
       - modeler
       - camunda-platform
-    profiles:
-      - ''
-      - web-modeler-standalone
 
   kibana:
     image: docker.elastic.co/kibana/kibana:${ELASTIC_VERSION}

--- a/docker-compose/versions/camunda-8.4/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.4/docker-compose.yaml
@@ -47,9 +47,6 @@ services:
     depends_on:
       - elasticsearch
       - identity
-    profiles:
-      - ''
-      - orchestration
 
   operate: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#operate
     image: camunda/operate:${CAMUNDA_OPERATE_VERSION}
@@ -94,9 +91,6 @@ services:
       - zeebe
       - identity
       - elasticsearch
-    profiles:
-      - ''
-      - orchestration
 
   tasklist: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#tasklist
     image: camunda/tasklist:${CAMUNDA_TASKLIST_VERSION}
@@ -144,9 +138,6 @@ services:
         condition: service_healthy
       identity:
         condition: service_healthy
-    profiles:
-      - ''
-      - orchestration
 
   connectors: # https://docs.camunda.io/docs/components/integration-framework/connectors/out-of-the-box-connectors/available-connectors-overview/
     image: camunda/connectors-bundle:${CAMUNDA_CONNECTORS_VERSION}
@@ -182,9 +173,6 @@ services:
       - zeebe
       - operate
       - identity
-    profiles:
-      - ''
-      - orchestration
 
   optimize: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#optimize
     image: camunda/optimize:${CAMUNDA_OPTIMIZE_VERSION}
@@ -222,9 +210,6 @@ services:
     depends_on:
       - identity
       - elasticsearch
-    profiles:
-      - ''
-      - orchestration
 
   identity: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#identity
     container_name: identity
@@ -283,9 +268,6 @@ services:
     depends_on:
       keycloak:
         condition: service_healthy
-    profiles:
-      - ''
-      - identity
 
   postgres: # https://hub.docker.com/_/postgres
     container_name: postgres
@@ -304,9 +286,6 @@ services:
       - postgres:/var/lib/postgresql/data
     networks:
       - identity-network
-    profiles:
-      - ''
-      - identity
 
   keycloak: # https://hub.docker.com/r/bitnami/keycloak
     container_name: keycloak
@@ -333,9 +312,6 @@ services:
       - identity-network
     depends_on:
       - postgres
-    profiles:
-      - ''
-      - identity
 
   elasticsearch: # https://hub.docker.com/_/elasticsearch
     image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION}
@@ -364,9 +340,6 @@ services:
       - elastic:/usr/share/elasticsearch/data
     networks:
       - camunda-platform
-    profiles:
-      - ''
-      - orchestration
 
   modeler-db:
     container_name: modeler-db
@@ -385,9 +358,6 @@ services:
       - camunda-platform
     volumes:
       - postgres-web:/var/lib/postgresql/data
-    profiles:
-      - ''
-      - web-modeler-standalone
 
   modeler-websockets:
     container_name: modeler-websockets
@@ -408,9 +378,6 @@ services:
     networks:
       - modeler
       - camunda-platform
-    profiles:
-      - ''
-      - web-modeler-standalone
 
   mailpit:
     # If you want to use your own SMTP server, you can remove this container
@@ -427,9 +394,6 @@ services:
     networks:
       - modeler
       - camunda-platform
-    profiles:
-      - ''
-      - web-modeler-standalone
 
   # Modeler containers
   modeler-restapi:
@@ -471,9 +435,6 @@ services:
     networks:
       - modeler
       - camunda-platform
-    profiles:
-      - ''
-      - web-modeler-standalone
 
   modeler-webapp:
     container_name: modeler-webapp
@@ -510,9 +471,6 @@ services:
     networks:
       - modeler
       - camunda-platform
-    profiles:
-      - ''
-      - web-modeler-standalone
 
   kibana:
     image: docker.elastic.co/kibana/kibana:${ELASTIC_VERSION}

--- a/docker-compose/versions/camunda-8.5/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.5/docker-compose.yaml
@@ -52,9 +52,6 @@ services:
     depends_on:
       - elasticsearch
       - identity
-    profiles:
-      - ''
-      - orchestration
 
   operate: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#operate
     image: camunda/operate:${CAMUNDA_OPERATE_VERSION}
@@ -99,9 +96,6 @@ services:
       - zeebe
       - identity
       - elasticsearch
-    profiles:
-      - ''
-      - orchestration
 
   tasklist: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#tasklist
     image: camunda/tasklist:${CAMUNDA_TASKLIST_VERSION}
@@ -150,9 +144,6 @@ services:
         condition: service_healthy
       identity:
         condition: service_healthy
-    profiles:
-      - ''
-      - orchestration
 
   connectors: # https://docs.camunda.io/docs/components/integration-framework/connectors/out-of-the-box-connectors/available-connectors-overview/
     image: camunda/connectors-bundle:${CAMUNDA_CONNECTORS_VERSION}
@@ -188,9 +179,6 @@ services:
       - zeebe
       - operate
       - identity
-    profiles:
-      - ''
-      - orchestration
 
   optimize: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#optimize
     image: camunda/optimize:${CAMUNDA_OPTIMIZE_VERSION}
@@ -228,9 +216,6 @@ services:
     depends_on:
       - identity
       - elasticsearch
-    profiles:
-      - ''
-      - orchestration
 
   identity: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#identity
     container_name: identity
@@ -299,9 +284,6 @@ services:
     depends_on:
       keycloak:
         condition: service_healthy
-    profiles:
-      - ''
-      - identity
 
   postgres: # https://hub.docker.com/_/postgres
     container_name: postgres
@@ -320,9 +302,6 @@ services:
       - postgres:/var/lib/postgresql/data
     networks:
       - identity-network
-    profiles:
-      - ''
-      - identity
 
   keycloak: # https://hub.docker.com/r/bitnami/keycloak
     container_name: keycloak
@@ -350,9 +329,6 @@ services:
       - identity-network
     depends_on:
       - postgres
-    profiles:
-      - ''
-      - identity
 
   elasticsearch: # https://hub.docker.com/_/elasticsearch
     image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION}
@@ -381,9 +357,6 @@ services:
       - elastic:/usr/share/elasticsearch/data
     networks:
       - camunda-platform
-    profiles:
-      - ''
-      - orchestration
 
   modeler-db:
     container_name: modeler-db
@@ -401,9 +374,6 @@ services:
       - modeler
     volumes:
       - postgres-web:/var/lib/postgresql/data
-    profiles:
-      - ''
-      - web-modeler-standalone
 
   modeler-websockets:
     container_name: modeler-websockets
@@ -423,9 +393,6 @@ services:
       PUSHER_APP_SECRET: modeler-app-secret
     networks:
       - modeler
-    profiles:
-      - ''
-      - web-modeler-standalone
 
   mailpit:
     # If you want to use your own SMTP server, you can remove this container
@@ -441,9 +408,6 @@ services:
       interval: 30s
     networks:
       - modeler
-    profiles:
-      - ''
-      - web-modeler-standalone
 
   # Modeler containers
   modeler-restapi:
@@ -485,9 +449,6 @@ services:
     networks:
     - modeler
     - camunda-platform
-    profiles:
-      - ''
-      - web-modeler-standalone
 
   modeler-webapp:
     container_name: modeler-webapp
@@ -524,9 +485,6 @@ services:
     networks:
       - modeler
       - camunda-platform
-    profiles:
-      - ''
-      - web-modeler-standalone
 
   kibana:
     image: docker.elastic.co/kibana/kibana:${ELASTIC_VERSION}

--- a/docker-compose/versions/camunda-8.6/docker-compose-web-modeler.yaml
+++ b/docker-compose/versions/camunda-8.6/docker-compose-web-modeler.yaml
@@ -22,9 +22,6 @@ services:
       - web-modeler
     volumes:
       - postgres-web:/var/lib/postgresql/data
-    profiles:
-      - ''
-      - web-modeler-standalone
 
   web-modeler-websockets:
     container_name: web-modeler-websockets
@@ -44,9 +41,6 @@ services:
       PUSHER_APP_SECRET: web-modeler-app-secret
     networks:
       - web-modeler
-    profiles:
-      - ''
-      - web-modeler-standalone
 
   mailpit:
     # If you want to use your own SMTP server, you can remove this container
@@ -62,9 +56,6 @@ services:
       interval: 30s
     networks:
       - web-modeler
-    profiles:
-      - ''
-      - web-modeler-standalone
 
   # Modeler containers
   web-modeler-restapi:
@@ -106,9 +97,6 @@ services:
     networks:
       - web-modeler
       - camunda-platform
-    profiles:
-      - ''
-      - web-modeler
 
   web-modeler-webapp:
     container_name: web-modeler-webapp
@@ -145,9 +133,6 @@ services:
     networks:
       - web-modeler
       - camunda-platform
-    profiles:
-      - ''
-      - web-modeler-standalone
 
   ## Dependencies: identity, keycloak, postgres for keycloak
   identity: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#identity
@@ -221,9 +206,6 @@ services:
     depends_on:
       keycloak:
         condition: service_healthy
-    profiles:
-      - ''
-      - identity
 
   postgres: # https://hub.docker.com/_/postgres
     container_name: postgres
@@ -242,9 +224,6 @@ services:
       - postgres:/var/lib/postgresql/data
     networks:
       - identity-network
-    profiles:
-      - ''
-      - identity
 
   keycloak: # https://hub.docker.com/r/bitnami/keycloak
     container_name: keycloak
@@ -272,9 +251,6 @@ services:
       - identity-network
     depends_on:
       - postgres
-    profiles:
-      - ''
-      - identity
 
 networks:
   camunda-platform:

--- a/docker-compose/versions/camunda-8.6/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.6/docker-compose.yaml
@@ -51,9 +51,6 @@ services:
     depends_on:
       - elasticsearch
       - identity
-    profiles:
-      - ''
-      - orchestration
 
   operate: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#operate
     image: camunda/operate:${CAMUNDA_OPERATE_VERSION}
@@ -99,9 +96,6 @@ services:
       - zeebe
       - identity
       - elasticsearch
-    profiles:
-      - ''
-      - orchestration
 
   tasklist: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#tasklist
     image: camunda/tasklist:${CAMUNDA_TASKLIST_VERSION}
@@ -151,9 +145,6 @@ services:
         condition: service_healthy
       identity:
         condition: service_healthy
-    profiles:
-      - ''
-      - orchestration
 
   connectors: # https://docs.camunda.io/docs/components/integration-framework/connectors/out-of-the-box-connectors/available-connectors-overview/
     image: camunda/connectors-bundle:${CAMUNDA_CONNECTORS_VERSION}
@@ -190,9 +181,6 @@ services:
       - zeebe
       - operate
       - identity
-    profiles:
-      - ''
-      - orchestration
 
   optimize: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#optimize
     image: camunda/optimize:${CAMUNDA_OPTIMIZE_VERSION}
@@ -230,9 +218,6 @@ services:
     depends_on:
       - identity
       - elasticsearch
-    profiles:
-      - ''
-      - orchestration
 
   identity: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#identity
     container_name: identity
@@ -305,9 +290,6 @@ services:
     depends_on:
       keycloak:
         condition: service_healthy
-    profiles:
-      - ''
-      - identity
 
   postgres: # https://hub.docker.com/_/postgres
     container_name: postgres
@@ -326,9 +308,6 @@ services:
       - postgres:/var/lib/postgresql/data
     networks:
       - identity-network
-    profiles:
-      - ''
-      - identity
 
   keycloak: # https://hub.docker.com/r/bitnami/keycloak
     container_name: keycloak
@@ -356,9 +335,6 @@ services:
       - identity-network
     depends_on:
       - postgres
-    profiles:
-      - ''
-      - identity
 
   elasticsearch: # https://hub.docker.com/_/elasticsearch
     image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION}
@@ -387,9 +363,6 @@ services:
       - elastic:/usr/share/elasticsearch/data
     networks:
       - camunda-platform
-    profiles:
-      - ''
-      - orchestration
 
   web-modeler-db:
     container_name: web-modeler-db
@@ -407,9 +380,6 @@ services:
       - web-modeler
     volumes:
       - postgres-web:/var/lib/postgresql/data
-    profiles:
-      - ''
-      - web-modeler
 
   mailpit:
     # If you want to use your own SMTP server, you can remove this container
@@ -424,9 +394,6 @@ services:
       test: /usr/bin/nc -v localhost 1025
       interval: 30s
     networks:
-      - web-modeler
-    profiles:
-      - ''
       - web-modeler
 
   web-modeler-restapi:
@@ -478,9 +445,6 @@ services:
     networks:
       - web-modeler
       - camunda-platform
-    profiles:
-      - ''
-      - web-modeler
 
   web-modeler-webapp:
     container_name: web-modeler-webapp
@@ -517,9 +481,6 @@ services:
     networks:
       - web-modeler
       - camunda-platform
-    profiles:
-      - ''
-      - web-modeler
 
   web-modeler-websockets:
     container_name: web-modeler-websockets
@@ -538,9 +499,6 @@ services:
       PUSHER_APP_KEY: web-modeler-app-key
       PUSHER_APP_SECRET: web-modeler-app-secret
     networks:
-      - web-modeler
-    profiles:
-      - ''
       - web-modeler
 
   kibana:

--- a/docker-compose/versions/camunda-8.7/docker-compose-web-modeler.yaml
+++ b/docker-compose/versions/camunda-8.7/docker-compose-web-modeler.yaml
@@ -22,9 +22,6 @@ services:
       - web-modeler
     volumes:
       - postgres-web:/var/lib/postgresql/data
-    profiles:
-      - ''
-      - web-modeler-standalone
 
   web-modeler-websockets:
     container_name: web-modeler-websockets
@@ -44,9 +41,6 @@ services:
       PUSHER_APP_SECRET: web-modeler-app-secret
     networks:
       - web-modeler
-    profiles:
-      - ''
-      - web-modeler-standalone
 
   mailpit:
     # If you want to use your own SMTP server, you can remove this container
@@ -62,9 +56,6 @@ services:
       interval: 30s
     networks:
       - web-modeler
-    profiles:
-      - ''
-      - web-modeler-standalone
 
   # Modeler containers
   web-modeler-restapi:
@@ -106,9 +97,6 @@ services:
     networks:
       - web-modeler
       - camunda-platform
-    profiles:
-      - ''
-      - web-modeler
 
   web-modeler-webapp:
     container_name: web-modeler-webapp
@@ -145,9 +133,6 @@ services:
     networks:
       - web-modeler
       - camunda-platform
-    profiles:
-      - ''
-      - web-modeler-standalone
 
   ## Dependencies: identity, keycloak, postgres for keycloak
   identity: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#identity
@@ -221,9 +206,6 @@ services:
     depends_on:
       keycloak:
         condition: service_healthy
-    profiles:
-      - ''
-      - identity
 
   postgres: # https://hub.docker.com/_/postgres
     container_name: postgres
@@ -242,9 +224,6 @@ services:
       - postgres:/var/lib/postgresql/data
     networks:
       - identity-network
-    profiles:
-      - ''
-      - identity
 
   keycloak: # https://hub.docker.com/r/bitnami/keycloak
     container_name: keycloak
@@ -272,9 +251,6 @@ services:
       - identity-network
     depends_on:
       - postgres
-    profiles:
-      - ''
-      - identity
 
 networks:
   camunda-platform:

--- a/docker-compose/versions/camunda-8.7/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.7/docker-compose.yaml
@@ -56,9 +56,6 @@ services:
     depends_on:
       - elasticsearch
       - identity
-    profiles:
-      - ''
-      - orchestration
 
   operate: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#operate
     image: camunda/operate:${CAMUNDA_OPERATE_VERSION}
@@ -105,9 +102,6 @@ services:
       - zeebe
       - identity
       - elasticsearch
-    profiles:
-      - ''
-      - orchestration
 
   tasklist: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#tasklist
     image: camunda/tasklist:${CAMUNDA_TASKLIST_VERSION}
@@ -161,9 +155,6 @@ services:
         condition: service_healthy
       identity:
         condition: service_healthy
-    profiles:
-      - ''
-      - orchestration
 
   connectors: # https://docs.camunda.io/docs/components/integration-framework/connectors/out-of-the-box-connectors/available-connectors-overview/
     image: camunda/connectors-bundle:${CAMUNDA_CONNECTORS_VERSION}
@@ -209,9 +200,6 @@ services:
       - zeebe
       - operate
       - identity
-    profiles:
-      - ''
-      - orchestration
 
   optimize: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#optimize
     image: camunda/optimize:${CAMUNDA_OPTIMIZE_VERSION}
@@ -249,9 +237,6 @@ services:
     depends_on:
       - identity
       - elasticsearch
-    profiles:
-      - ''
-      - orchestration
 
   identity: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#identity
     container_name: identity
@@ -324,9 +309,6 @@ services:
     depends_on:
       keycloak:
         condition: service_healthy
-    profiles:
-      - ''
-      - identity
 
   postgres: # https://hub.docker.com/_/postgres
     container_name: postgres
@@ -345,9 +327,6 @@ services:
       - postgres:/var/lib/postgresql/data
     networks:
       - identity-network
-    profiles:
-      - ''
-      - identity
 
   keycloak: # https://hub.docker.com/r/bitnami/keycloak
     container_name: keycloak
@@ -375,9 +354,6 @@ services:
       - identity-network
     depends_on:
       - postgres
-    profiles:
-      - ''
-      - identity
 
   elasticsearch: # https://hub.docker.com/_/elasticsearch
     image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION}
@@ -406,9 +382,6 @@ services:
       - elastic:/usr/share/elasticsearch/data
     networks:
       - camunda-platform
-    profiles:
-      - ''
-      - orchestration
 
   web-modeler-db:
     container_name: web-modeler-db
@@ -426,9 +399,6 @@ services:
       - web-modeler
     volumes:
       - postgres-web:/var/lib/postgresql/data
-    profiles:
-      - ''
-      - web-modeler
 
   mailpit:
     # If you want to use your own SMTP server, you can remove this container
@@ -443,9 +413,6 @@ services:
       test: /usr/bin/nc -v localhost 1025
       interval: 30s
     networks:
-      - web-modeler
-    profiles:
-      - ''
       - web-modeler
 
   web-modeler-restapi:
@@ -496,9 +463,6 @@ services:
     networks:
       - web-modeler
       - camunda-platform
-    profiles:
-      - ''
-      - web-modeler
 
   web-modeler-webapp:
     container_name: web-modeler-webapp
@@ -535,9 +499,6 @@ services:
     networks:
       - web-modeler
       - camunda-platform
-    profiles:
-      - ''
-      - web-modeler
 
   web-modeler-websockets:
     container_name: web-modeler-websockets
@@ -556,9 +517,6 @@ services:
       PUSHER_APP_KEY: web-modeler-app-key
       PUSHER_APP_SECRET: web-modeler-app-secret
     networks:
-      - web-modeler
-    profiles:
-      - ''
       - web-modeler
 
   kibana:


### PR DESCRIPTION
As discussed in https://github.com/camunda/camunda-distributions/issues/110

We remove profiles to avoid confusion as we don't use them by default.