### PR TITLE
fix(docker-compose): increase web modeler rest-api memory

### DIFF
--- a/docker-compose/versions/camunda-8.3/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.3/docker-compose.yaml
@@ -393,7 +393,7 @@ services:
       timeout: 15s
       retries: 30
     environment:
-      JAVA_OPTIONS: -Xmx128m
+      JAVA_OPTIONS: -Xmx512m
       LOGGING_LEVEL_IO_CAMUNDA_MODELER: DEBUG
       SPRING_DATASOURCE_URL: jdbc:postgresql://modeler-db:5432/modeler-db
       SPRING_DATASOURCE_USERNAME: modeler-db-user

--- a/docker-compose/versions/camunda-8.4/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.4/docker-compose.yaml
@@ -413,7 +413,7 @@ services:
       timeout: 15s
       retries: 30
     environment:
-      JAVA_OPTIONS: -Xmx128m
+      JAVA_OPTIONS: -Xmx512m
       LOGGING_LEVEL_IO_CAMUNDA_MODELER: DEBUG
       CAMUNDA_IDENTITY_BASEURL: http://identity:8084/
       SPRING_DATASOURCE_URL: jdbc:postgresql://modeler-db:5432/modeler-db

--- a/docker-compose/versions/camunda-8.5/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.5/docker-compose.yaml
@@ -427,7 +427,7 @@ services:
       timeout: 15s
       retries: 30
     environment:
-      JAVA_OPTIONS: -Xmx128m
+      JAVA_OPTIONS: -Xmx512m
       LOGGING_LEVEL_IO_CAMUNDA_MODELER: DEBUG
       CAMUNDA_IDENTITY_BASEURL: http://identity:8084/
       SPRING_DATASOURCE_URL: jdbc:postgresql://modeler-db:5432/modeler-db

--- a/docker-compose/versions/camunda-8.6/docker-compose-web-modeler.yaml
+++ b/docker-compose/versions/camunda-8.6/docker-compose-web-modeler.yaml
@@ -75,7 +75,7 @@ services:
       timeout: 15s
       retries: 30
     environment:
-      JAVA_OPTIONS: -Xmx128m
+      JAVA_OPTIONS: -Xmx512m
       LOGGING_LEVEL_IO_CAMUNDA_MODELER: DEBUG
       CAMUNDA_IDENTITY_BASEURL: http://identity:8084/
       SPRING_DATASOURCE_URL: jdbc:postgresql://web-modeler-db:5432/web-modeler-db

--- a/docker-compose/versions/camunda-8.6/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.6/docker-compose.yaml
@@ -413,7 +413,7 @@ services:
       timeout: 15s
       retries: 30
     environment:
-      JAVA_OPTIONS: -Xmx128m
+      JAVA_OPTIONS: -Xmx512m
       LOGGING_LEVEL_IO_CAMUNDA_MODELER: DEBUG
       CAMUNDA_IDENTITY_BASEURL: http://identity:8084/
       SPRING_DATASOURCE_URL: jdbc:postgresql://web-modeler-db:5432/web-modeler-db

--- a/docker-compose/versions/camunda-8.7/docker-compose-web-modeler.yaml
+++ b/docker-compose/versions/camunda-8.7/docker-compose-web-modeler.yaml
@@ -75,7 +75,7 @@ services:
       timeout: 15s
       retries: 30
     environment:
-      JAVA_OPTIONS: -Xmx128m
+      JAVA_OPTIONS: -Xmx512m
       LOGGING_LEVEL_IO_CAMUNDA_MODELER: DEBUG
       CAMUNDA_IDENTITY_BASEURL: http://identity:8084/
       SPRING_DATASOURCE_URL: jdbc:postgresql://web-modeler-db:5432/web-modeler-db

--- a/docker-compose/versions/camunda-8.7/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.7/docker-compose.yaml
@@ -432,7 +432,7 @@ services:
       timeout: 15s
       retries: 30
     environment:
-      JAVA_OPTIONS: -Xmx128m
+      JAVA_OPTIONS: -Xmx512m
       LOGGING_LEVEL_IO_CAMUNDA_MODELER: DEBUG
       CAMUNDA_IDENTITY_BASEURL: http://identity:8084/
       SPRING_DATASOURCE_URL: jdbc:postgresql://web-modeler-db:5432/web-modeler-db


### PR DESCRIPTION
The existing value might be too low and block the WM rest API from spinning up correctly, due to some `out of memory` error.