### PR TITLE
fix: added rest address and log level to connectors

### DIFF
--- a/docker-compose/versions/camunda-8.7/docker-compose-core.yaml
+++ b/docker-compose/versions/camunda-8.7/docker-compose-core.yaml
@@ -101,10 +101,13 @@ services:
     environment:
       - CAMUNDA_CLIENT_MODE=self-managed
       - CAMUNDA_CLIENT_ZEEBE_GRPCADDRESS=http://zeebe:26500
+      - CAMUNDA_CLIENT_ZEEBE_RESTADDRESS=http://zeebe:8080
       - OPERATE_CLIENT_BASEURL=http://operate:8080
       - OPERATE_CLIENT_PROFILE=simple
-      - management.endpoints.web.exposure.include=health
+      - management.endpoints.web.exposure.include=health,metrics
       - management.endpoint.health.probes.enabled=true
+      - logging.level.io.camunda.zeebe.client.impl.ZeebeCallCredentials=ERROR
+      - logging.level.io.camunda.connector.runtime.inbound.importer=ERROR
     healthcheck:
       test: [ "CMD-SHELL", "curl -f http://localhost:8080/actuator/health/readiness" ]
       interval: 30s


### PR DESCRIPTION
This PR adds the rest address to the connector runtime. Also, it adds a log level to suppress useless warnings