### PR TITLE
feat: upgrade postgres and keycloak for identity in 8.7 and 8.8

### DIFF
--- a/docker-compose/versions/camunda-8.7/.env
+++ b/docker-compose/versions/camunda-8.7/.env
@@ -15,10 +15,10 @@ CAMUNDA_OPTIMIZE_VERSION=8.7.7
 CAMUNDA_WEB_MODELER_VERSION=8.7.8
 # renovate: datasource=docker depName=elasticsearch
 ELASTIC_VERSION=8.17.9
-KEYCLOAK_SERVER_VERSION=24.0.5
+KEYCLOAK_SERVER_VERSION=26.3.2
 # renovate: datasource=docker depName=axllent/mailpit
 MAILPIT_VERSION=v1.21.8
-POSTGRES_VERSION=14.5-alpine
+POSTGRES_VERSION=17.5-alpine
 HOST=localhost
 KEYCLOAK_HOST=localhost
 

--- a/docker-compose/versions/camunda-8.8/.env
+++ b/docker-compose/versions/camunda-8.8/.env
@@ -15,10 +15,10 @@ CAMUNDA_OPTIMIZE_VERSION=8.8.0-alpha7
 CAMUNDA_WEB_MODELER_VERSION=8.8.0-alpha7
 # renovate: datasource=docker depName=elasticsearch
 ELASTIC_VERSION=8.17.5
-KEYCLOAK_SERVER_VERSION=24.0.5
+KEYCLOAK_SERVER_VERSION=26.3.2
 # renovate: datasource=docker depName=axllent/mailpit
 MAILPIT_VERSION=v1.21.8
-POSTGRES_VERSION=14.5-alpine
+POSTGRES_VERSION=17.5-alpine
 HOST=localhost
 KEYCLOAK_HOST=localhost
 


### PR DESCRIPTION
https://github.com/camunda/team-distribution/issues/434#issuecomment-3181916627

I did some basic testing, spinning up the compose files with `docker compose up -d` and logging into identity and keycloak to make sure all the roles and applications loaded correctly. Logged into operate and deployed a model / viewed in operate. everything seemed fine.