### PR TITLE
feat: add console to 8.8 docker compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,49 @@
+# Node.js dependencies
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+package-lock.json
+
+# Playwright testing artifacts
+test-results/
+playwright-report/
+playwright/.cache/
+*.png
+*.jpg
+*.jpeg
+*.gif
+
+# Docker Compose runtime files
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Console configuration (runtime generated)
+docker-compose/versions/*/.console/
+
+# Logs
+logs/
+*.log
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Temporary files
+*.tmp
+*.temp
+.cache/

--- a/docker-compose/test/e2e/tests/console_login.spec.ts
+++ b/docker-compose/test/e2e/tests/console_login.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+
+test('Validate login page', async ({ page }) => {
+  test.setTimeout(60000);
+  await page.goto('http://localhost:8089/');
+  await page.getByRole('heading', { name: 'Log in' }).waitFor();
+  await page.getByLabel('Username or email').click();
+  await page.getByLabel('Username or email').fill('demo');
+  await page.getByLabel('Password').click();
+  await page.getByLabel('Password').fill('demo');
+  await page.getByRole('button', { name: 'Log in' }).click();
+  await page.getByText('Cluster health').waitFor();
+});

--- a/docker-compose/versions/camunda-8.8/.env
+++ b/docker-compose/versions/camunda-8.8/.env
@@ -13,6 +13,8 @@ CAMUNDA_TASKLIST_VERSION=8.8.0-alpha7
 CAMUNDA_OPTIMIZE_VERSION=8.8.0-alpha7
 # renovate: datasource=docker depName=camunda/web-modeler-restapi
 CAMUNDA_WEB_MODELER_VERSION=8.8.0-alpha8-rc1
+# renovate: datasource=docker depName=camunda/console
+CAMUNDA_CONSOLE_VERSION=8.8.0-alpha7
 # renovate: datasource=docker depName=elasticsearch
 ELASTIC_VERSION=8.17.5
 KEYCLOAK_SERVER_VERSION=24.0.5

--- a/docker-compose/versions/camunda-8.8/docker-compose.yaml
+++ b/docker-compose/versions/camunda-8.8/docker-compose.yaml
@@ -149,6 +149,8 @@ services:
       KEYCLOAK_INIT_WEBMODELER_ROOT_URL: http://${HOST}:8070
       KEYCLOAK_INIT_CONNECTORS_SECRET: XALaRPl5qwTEItdwCMiPS62nVpKs7dL7
       KEYCLOAK_INIT_CONNECTORS_ROOT_URL: http://${HOST}:8085
+      KEYCLOAK_INIT_CONSOLE_SECRET: XALaRPl5qwTEItdwCMiPS62nVpKs7dL7
+      KEYCLOAK_INIT_CONSOLE_ROOT_URL: http://${HOST}:8089
       KEYCLOAK_INIT_ZEEBE_NAME: zeebe
       KEYCLOAK_USERS_0_USERNAME: "demo"
       KEYCLOAK_USERS_0_PASSWORD: "demo"
@@ -161,6 +163,7 @@ services:
       KEYCLOAK_USERS_0_ROLES_4: "Web Modeler"
       KEYCLOAK_USERS_0_ROLES_5: "Web Modeler Admin"
       KEYCLOAK_USERS_0_ROLES_6: "Zeebe"
+      KEYCLOAK_USERS_0_ROLES_7: "Console"
       KEYCLOAK_CLIENTS_0_NAME: zeebe
       KEYCLOAK_CLIENTS_0_ID: ${ZEEBE_CLIENT_ID}
       KEYCLOAK_CLIENTS_0_SECRET: ${ZEEBE_CLIENT_SECRET}
@@ -407,6 +410,37 @@ services:
       PUSHER_APP_SECRET: web-modeler-app-secret
     networks:
       - web-modeler
+
+  console:
+    container_name: console
+    image: camunda/console:${CAMUNDA_CONSOLE_VERSION}
+    ports:
+      - "8089:8080"
+      - "9100:9100"
+    environment:
+      NODE_ENV: production
+      KEYCLOAK_BASE_URL: http://${KEYCLOAK_HOST}:18080/auth
+      KEYCLOAK_INTERNAL_BASE_URL: http://keycloak:18080/auth
+      KEYCLOAK_REALM: camunda-platform
+      CAMUNDA_IDENTITY_CLIENT_ID: console
+      CAMUNDA_IDENTITY_AUDIENCE: console-api
+      JAVA_TOOL_OPTIONS: -Xms512m -Xmx1g
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:9100/health/readiness || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    restart: on-failure
+    volumes:
+      - "./.console:/var/run/config"
+    networks:
+      - camunda-platform
+    depends_on:
+      identity:
+        condition: service_healthy
+      keycloak:
+        condition: service_healthy
 
 volumes:
   zeebe:


### PR DESCRIPTION
Closes: https://github.com/camunda/product-hub/issues/2242

Adds the console component to docker-compose.yaml as well as a basic login test