### PR TITLE
docs(docker-compose): correct bundled JDBC driver list and link releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Camunda 8 Self-Managed Distributions (setup, deploy, etc.) mono repo for [Camund
 
 ### Docker Compose
 
-For more details, check the directory of [Camunda Docker Compose](./docker-compose/).
+Download the versioned distribution archive from [Releases](https://github.com/camunda/camunda-distributions/releases). The [Docker Compose quickstart](https://docs.camunda.io/docs/self-managed/quickstart/developer-quickstart/docker-compose/) covers installing and starting it.
+
+For the sources behind those archives, check the directory of [Camunda Docker Compose](./docker-compose/).
 
 ## Documentation
 

--- a/docker-compose/versions/camunda-8.10/README.md
+++ b/docker-compose/versions/camunda-8.10/README.md
@@ -48,11 +48,11 @@ export ORCHESTRATION_CONFIG_FILE=application-mysql.yaml
 docker compose up -d
 ```
 
-The `application-opensearch.yaml` sample expects an OpenSearch instance reachable at `http://opensearch:9200`. OpenSearch is not bundled, so either point the URL at an existing instance or add one via a `docker-compose.override.yaml` on the same network — see [configure secondary storage with Docker Compose](https://docs.camunda.io/docs/self-managed/quickstart/developer-quickstart/docker-compose/secondary-storage/) for a ready-made example.
+The `application-opensearch.yaml` sample expects an OpenSearch instance reachable at `http://opensearch:9200`. OpenSearch is not bundled, so either point the URL at an existing instance or add one via a `docker-compose.override.yaml` on the same network — see [configure secondary storage with Docker Compose](https://docs.camunda.io/docs/next/self-managed/quickstart/developer-quickstart/docker-compose/secondary-storage/) for a ready-made example.
 
 ### JDBC drivers
 
-The Camunda Docker image automatically loads any `.jar` dropped into `/driver-lib`. A writable `driver-lib/` folder is included next to the compose file so you can copy the vendor JDBC driver there before starting (e.g., `driver-lib/mysql-connector-j-9.0.0.jar`). This is required for MySQL and Oracle. PostgreSQL, MariaDB, SQL Server, and H2 drivers are already bundled in the image — see [supported JDBC driver versions](https://docs.camunda.io/docs/self-managed/concepts/databases/relational-db/rdbms-support-policy/#bundled-drivers) for the authoritative list.
+The Camunda Docker image automatically loads any `.jar` dropped into `/driver-lib`. A writable `driver-lib/` folder is included next to the compose file so you can copy the vendor JDBC driver there before starting (e.g., `driver-lib/mysql-connector-j-9.0.0.jar`). This is required for MySQL and Oracle. PostgreSQL, MariaDB, SQL Server, and H2 drivers are already bundled in the image — see [supported JDBC driver versions](https://docs.camunda.io/docs/next/self-managed/concepts/databases/relational-db/rdbms-support-policy/#bundled-drivers) for the authoritative list.
 
 ## Enabling multi-tenancy
 

--- a/docker-compose/versions/camunda-8.10/README.md
+++ b/docker-compose/versions/camunda-8.10/README.md
@@ -52,7 +52,7 @@ The `application-opensearch.yaml` sample expects an OpenSearch instance reachabl
 
 ### JDBC drivers
 
-The Camunda Docker image automatically loads any `.jar` dropped into `/driver-lib`. A writable `driver-lib/` folder is included next to the compose file so you can copy the vendor JDBC driver there before starting (e.g., `driver-lib/mysql-connector-j-9.0.0.jar`). This is required for MySQL/MariaDB, SQL Server, and Oracle. PostgreSQL and H2 drivers are already bundled.
+The Camunda Docker image automatically loads any `.jar` dropped into `/driver-lib`. A writable `driver-lib/` folder is included next to the compose file so you can copy the vendor JDBC driver there before starting (e.g., `driver-lib/mysql-connector-j-9.0.0.jar`). This is required for MySQL and Oracle. PostgreSQL, MariaDB, SQL Server, and H2 drivers are already bundled in the image — see [supported JDBC driver versions](https://docs.camunda.io/docs/self-managed/concepts/databases/relational-db/rdbms-support-policy/#bundled-drivers) for the authoritative list.
 
 ## Enabling multi-tenancy
 

--- a/docker-compose/versions/camunda-8.7/README.md
+++ b/docker-compose/versions/camunda-8.7/README.md
@@ -2,7 +2,7 @@
 
 ## Usage
 
-For end user usage, please check the offical documentation of [Camunda 8 Self-Managed Docker Compose](https://docs.camunda.io/docs/self-managed/setup/deploy/local/docker-compose/).
+For end user usage, please check the offical documentation of [Camunda 8 Self-Managed Docker Compose](https://docs.camunda.io/docs/8.7/self-managed/setup/deploy/local/docker-compose/).
 
 ## Enabling multi-tenancy
 

--- a/docker-compose/versions/camunda-8.8/README.md
+++ b/docker-compose/versions/camunda-8.8/README.md
@@ -2,7 +2,7 @@
 
 ## Usage
 
-For end user usage, please check the official documentation of [Camunda 8 Self-Managed Docker Compose](https://docs.camunda.io/docs/next/self-managed/quickstart/developer-quickstart/docker-compose/).
+For end user usage, please check the official documentation of [Camunda 8 Self-Managed Docker Compose](https://docs.camunda.io/docs/8.8/self-managed/quickstart/developer-quickstart/docker-compose/).
 
 ## Application configuration
 

--- a/docker-compose/versions/camunda-8.9/README.md
+++ b/docker-compose/versions/camunda-8.9/README.md
@@ -14,6 +14,10 @@ Camunda services read their application settings from YAML mounted by Docker Com
 
 The mounted files reference values from `.env` with `${VARIABLE:default}` placeholders. Keep environment-specific endpoints and secrets in `.env`; direct Spring environment variables can still override file values. PostgreSQL, Keycloak, Elasticsearch, Web Modeler WebSockets, Console, and other non-Spring services continue to use their native environment-based configuration.
 
+## JDBC drivers
+
+The Camunda Docker image automatically loads any `.jar` dropped into `/driver-lib`. A writable `driver-lib/` folder is included next to the compose file so you can copy the vendor JDBC driver there before starting (e.g., `driver-lib/mysql-connector-j-9.0.0.jar`). This is required for MySQL and Oracle. PostgreSQL, MariaDB, SQL Server, and H2 drivers are already bundled in the image — see [supported JDBC driver versions](https://docs.camunda.io/docs/self-managed/concepts/databases/relational-db/rdbms-support-policy/#bundled-drivers) for the authoritative list.
+
 ## Enabling multi-tenancy
 
 ### Lightweight configuration

--- a/docker-compose/versions/camunda-8.9/README.md
+++ b/docker-compose/versions/camunda-8.9/README.md
@@ -2,7 +2,7 @@
 
 ## Usage
 
-For end user usage, please check the official documentation of [Camunda 8 Self-Managed Docker Compose](https://docs.camunda.io/docs/next/self-managed/quickstart/developer-quickstart/docker-compose/).
+For end user usage, please check the official documentation of [Camunda 8 Self-Managed Docker Compose](https://docs.camunda.io/docs/self-managed/quickstart/developer-quickstart/docker-compose/).
 
 ## Application configuration
 
@@ -13,6 +13,29 @@ Camunda services read their application settings from YAML mounted by Docker Com
 - The full setup additionally uses `.orchestration/application.yaml`, `.connectors/application.yaml`, and the files under `.optimize/`. Web Modeler cluster registrations are isolated in `.web-modeler/application-full.yaml`.
 
 The mounted files reference values from `.env` with `${VARIABLE:default}` placeholders. Keep environment-specific endpoints and secrets in `.env`; direct Spring environment variables can still override file values. PostgreSQL, Keycloak, Elasticsearch, Web Modeler WebSockets, Console, and other non-Spring services continue to use their native environment-based configuration.
+
+## Switching secondary storage databases
+
+The Orchestration container mounts `configuration/<file>.yaml` into `/usr/local/camunda/config/application.yaml`.
+Set `ORCHESTRATION_CONFIG_FILE` in `.env` (or export it before running `docker compose`) to one of the provided samples:
+
+- `application-h2.yaml` (default, file-based H2)
+- `application-mysql.yaml`
+- `application-mariadb.yaml`
+- `application-postgresql.yaml`
+- `application-mssql.yaml`
+- `application-oracle.yaml`
+- `application-opensearch.yaml`
+
+Feel free to copy these files and adjust the JDBC URL/credentials for your environment. Example:
+
+```bash
+cd docker-compose/versions/camunda-8.9
+export ORCHESTRATION_CONFIG_FILE=application-mysql.yaml
+docker compose up -d
+```
+
+The `application-opensearch.yaml` sample expects an OpenSearch instance reachable at `http://opensearch:9200`. OpenSearch is not bundled, so either point the URL at an existing instance or add one via a `docker-compose.override.yaml` on the same network — see [configure secondary storage with Docker Compose](https://docs.camunda.io/docs/self-managed/quickstart/developer-quickstart/docker-compose/secondary-storage/) for a ready-made example.
 
 ## JDBC drivers
 

--- a/docker-compose/versions/camunda-8.9/README.md
+++ b/docker-compose/versions/camunda-8.9/README.md
@@ -37,7 +37,7 @@ docker compose up -d
 
 The `application-opensearch.yaml` sample expects an OpenSearch instance reachable at `http://opensearch:9200`. OpenSearch is not bundled, so either point the URL at an existing instance or add one via a `docker-compose.override.yaml` on the same network — see [configure secondary storage with Docker Compose](https://docs.camunda.io/docs/self-managed/quickstart/developer-quickstart/docker-compose/secondary-storage/) for a ready-made example.
 
-## JDBC drivers
+### JDBC drivers
 
 The Camunda Docker image automatically loads any `.jar` dropped into `/driver-lib`. A writable `driver-lib/` folder is included next to the compose file so you can copy the vendor JDBC driver there before starting (e.g., `driver-lib/mysql-connector-j-9.0.0.jar`). This is required for MySQL and Oracle. PostgreSQL, MariaDB, SQL Server, and H2 drivers are already bundled in the image — see [supported JDBC driver versions](https://docs.camunda.io/docs/self-managed/concepts/databases/relational-db/rdbms-support-policy/#bundled-drivers) for the authoritative list.
 


### PR DESCRIPTION
Closes #604.

- Corrects the 8.10 JDBC driver statement: MariaDB and SQL Server are bundled in the Camunda image, so only MySQL and Oracle need a JAR in `driver-lib/`. Links the [supported JDBC driver versions](https://docs.camunda.io/docs/next/self-managed/concepts/databases/relational-db/rdbms-support-policy/#bundled-drivers) list instead of restating it.
- Adds the same JDBC driver section to 8.9, which ships `driver-lib/` but never documented it.
- Documents `ORCHESTRATION_CONFIG_FILE` and the `configuration/` samples in 8.9, matching 8.10.
- Points each version README at its own documentation version: 8.7 to `/docs/8.7/`, 8.8 to `/docs/8.8/`, 8.9 to the current default, 8.10 to `/docs/next/`.
- Points the root README at the Releases page and the Docker Compose quickstart, so users arriving from the documentation have a download path.
