### PR TITLE
fix(docker-compose): send Optimize's own client secret in 8.8 login

### DIFF
--- a/docker-compose/versions/camunda-8.8/docker-compose-full.yaml
+++ b/docker-compose/versions/camunda-8.8/docker-compose-full.yaml
@@ -81,6 +81,10 @@ services:
     ports:
       - "8083:8090"
     environment:
+      # env_file below pulls in CAMUNDA_IDENTITY_CLIENT_SECRET, which Spring binds to
+      # camunda.identity.clientSecret and which outranks application-ccsm.yaml. Without
+      # this override Optimize authenticates as client "optimize" using Identity's secret.
+      CAMUNDA_IDENTITY_CLIENT_SECRET: ${OPTIMIZE_CLIENT_SECRET}
       HOST: ${HOST}
       KEYCLOAK_HOST: ${KEYCLOAK_HOST}
       OPTIMIZE_CLIENT_SECRET: ${OPTIMIZE_CLIENT_SECRET}


### PR DESCRIPTION
## Why

`optimize_login` fails in the `camunda-8.8` profile with:

> User has no authorization to access Optimize. Please check your Identity configuration

The message points at Identity permissions, but the demo user's roles are fine. Keycloak is rejecting the authorization-code exchange with `401 unauthorized_client — Invalid client or Invalid client credentials`, which `CCSMTokenService` wraps as `NotAuthorizedException("Token exchange failed")` and Optimize renders as a generic 403.

I proxied Optimize's outbound calls to Keycloak and captured the token request:

```
POST /auth/realms/camunda-platform/protocol/openid-connect/token
BODY: client_id=optimize&client_secret=demo-identity-secret&...
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

That is `CAMUNDA_IDENTITY_CLIENT_SECRET`. The correct value is `demo-optimize-secret`.

The Optimize service loads the shared `.env` via `env_file`, and the 8.8 `.env` defines `CAMUNDA_IDENTITY_CLIENT_SECRET` for Identity's own Keycloak client. Spring's relaxed binding maps that variable onto `camunda.identity.clientSecret` — exactly the property `.optimize/application-ccsm.yaml` sets to `${OPTIMIZE_CLIENT_SECRET}` — and environment variables outrank config files. So Identity's secret silently wins.

Only 8.8 is affected:

| profile | `.env` defines `CAMUNDA_IDENTITY_CLIENT_SECRET` | `optimize_login` |
|---|---|---|
| 8.7 | no | passes |
| 8.8 | **yes → collides** | **fails** |
| 8.9 | no | passes |
| 8.10 | no | passes |

## What changed

One explicit override in the `optimize` service. `environment:` takes precedence over `env_file:`, so this restores the intended secret without touching the shared `.env` (which the other services and the image-tag interpolation still need).

## Verification

Ran the `camunda-8.8` full stack locally on `8.8.35` and drove the real Keycloak login.

Before:

- callback returns `403`, body `User has no authorization to access Optimize…`, page title `""`
- `Login callback failed: Token exchange failed` in the Optimize log

After:

- callback returns `200`, lands on `/static/redirect.html?url=http://localhost:8083/`
- `X-Optimize-Authorization` and `X-Optimize-Refresh-Token` cookies issued
- authenticated app root loads with title `Optimize`
- zero `Login callback failed` entries

Also ruled out: the `.env` and Keycloak secrets match; `client_credentials` auth with `demo-optimize-secret` works; and the code exchange succeeds when replayed by hand from both the host and inside the container.

## Note on 8.8.35

This is **not** a regression in 8.8.35, and 8.8.35 should not be reverted. The bug predates it. Before 8.8.35, the same rejection produced a redirect loop (camunda/camunda#35735), and the test passed against Chrome's `ERR_TOO_MANY_REDIRECTS` page — whose title is non-empty. 8.8.35 replaced that loop with a clean plain-text 403 whose title is `""`, and the only assertion that fires is `expect(title).not.toBe('')`.

Unblocks #702.

## Follow-up worth doing separately

`optimize_login.spec.ts` cannot distinguish a working Optimize from a browser error page — which is why this stayed invisible across multiple 8.8.x releases. It should assert on an actual Optimize UI element rather than `page.title()`.
