### PR TITLE
ci(github-actions): make the compose force-bump merge unattended

### DIFF
--- a/.github/workflows/ci-retry.yaml
+++ b/.github/workflows/ci-retry.yaml
@@ -1,9 +1,9 @@
 # type: Automation
 # owner: @camunda/distribution-team
 ---
-# Re-runs failed E2E jobs for Renovate PRs to absorb flaky failures, so a green
-# run lets the PR auto-merge. Capped at 3 attempts per run.
-name: Renovate - CI Retry
+# Re-runs failed E2E jobs for the auto-merging PR sources (Renovate, compose
+# force-bump). Capped at 3 attempts per run.
+name: CI Retry
 
 on:
   workflow_run:
@@ -18,7 +18,8 @@ jobs:
     name: Re-run failed jobs
     if: >-
       github.event.workflow_run.conclusion == 'failure' &&
-      startsWith(github.event.workflow_run.head_branch, 'renovate/') &&
+      (startsWith(github.event.workflow_run.head_branch, 'renovate/') ||
+      startsWith(github.event.workflow_run.head_branch, 'force-compose-bump/')) &&
       github.event.workflow_run.run_attempt < 3
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/docker-compose-force-bump.yaml
+++ b/.github/workflows/docker-compose-force-bump.yaml
@@ -154,8 +154,14 @@ jobs:
 
           # GITHUB_TOKEN is the distinct approver for the ruleset's 1-approval rule.
           gh pr review "${pr_url}" --approve
-          # Fail here rather than stall: nothing else approves this PR, so an ignored bot approval
-          # would leave it open until the caller's own wait expires.
+
+          # Auto-merge instead of immediate merge: the main ruleset's required checks take minutes,
+          # so an immediate merge is rejected with "base branch policy prohibits the merge" for the
+          # whole window. Auto-merge fires the moment the checks pass, still app-attributed.
+          GH_TOKEN="${APP_TOKEN}" gh pr merge "${pr_url}" --auto --squash --delete-branch
+
+          # Verified after arming, so a slow reviewDecision cannot leave the PR unarmed: nothing
+          # else approves this PR, and an approval GitHub declines to count stalls it silently.
           for _ in 1 2 3; do
             decision="$(GH_TOKEN="${APP_TOKEN}" gh pr view "${pr_url}" --json reviewDecision --jq .reviewDecision || true)"
             [ "${decision}" = "APPROVED" ] && break
@@ -166,12 +172,8 @@ jobs:
             exit 1
           fi
 
-          # Auto-merge instead of immediate merge: the main ruleset's required checks take minutes,
-          # so an immediate merge is rejected with "base branch policy prohibits the merge" for the
-          # whole window. Auto-merge fires the moment the checks pass, still app-attributed.
-          GH_TOKEN="${APP_TOKEN}" gh pr merge "${pr_url}" --auto --squash --delete-branch
-
-          # Bounded wait for the actual merge so this run's conclusion reflects reality.
+          # Bounded wait so the run reports the merge when it lands. Expiry only warns: auto-merge
+          # stays armed, and the caller polls the rolling release rather than this run.
           attempt=1
           max_attempts=60   # 60 x 30s = 30 min, within the job's 45 min timeout
           while :; do
@@ -187,8 +189,8 @@ jobs:
                 ;;
             esac
             if [ "${attempt}" -ge "${max_attempts}" ]; then
-              echo "::error::${pr_url} did not merge within ${max_attempts} polls — required checks did not pass in time. The PR stays open with auto-merge armed and still merges once they do."
-              exit 1
+              echo "::warning::${pr_url} has not merged within ${max_attempts} polls. Auto-merge stays armed, so it lands once the required checks pass and the rolling docker-compose-${MINOR} release rebuilds then."
+              break
             fi
             echo "  attempt ${attempt}/${max_attempts}: not merged yet (state: ${state:-unknown}); waiting 30s..."
             attempt=$((attempt + 1))

--- a/.github/workflows/docker-compose-force-bump.yaml
+++ b/.github/workflows/docker-compose-force-bump.yaml
@@ -37,7 +37,7 @@ jobs:
   force-bump:
     name: Force-bump camunda-${{ inputs.minor }}
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 45
     permissions:
       contents: write
       pull-requests: write
@@ -48,10 +48,6 @@ jobs:
         run: |
           echo "Action Inputs:"
           echo "${WORKFLOW_INPUTS}"
-
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          ref: main
 
       - name: Import Secrets
         id: secrets
@@ -67,15 +63,19 @@ jobs:
             secret/data/products/distribution/ci GH_APP_PRIVATE_KEY_DISTRO_CI;
             secret/data/products/distribution/ci SLACK_DISTRO_BOT_WEBHOOK;
 
-      # Distinct identity from github-actions[bot] (the PR opener) so its approval satisfies the
-      # main ruleset's 1-approval rule; merging with this token (not GITHUB_TOKEN) makes the push to
-      # main app-attributed, which is what triggers docker-compose-release.yaml.
+      # Owns the branch push, the PR and the merge: a GITHUB_TOKEN-opened PR parks its checks at
+      # action_required, and the app-attributed merge push is what triggers the rolling release.
       - name: Generate distro CI app token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ steps.secrets.outputs.GH_APP_ID_DISTRO_CI }}
           private-key: ${{ steps.secrets.outputs.GH_APP_PRIVATE_KEY_DISTRO_CI }}
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: main
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Author the .env from componentVersions
         id: author
@@ -146,16 +146,25 @@ jobs:
           git commit -m "deps(docker-compose): force-bump camunda-${MINOR} component versions"
           git push origin "${pr_branch}"
 
-          # Opened as github-actions[bot] (GITHUB_TOKEN) so the distro app is a distinct approver.
-          pr_url="$(gh pr create \
+          pr_url="$(GH_TOKEN="${APP_TOKEN}" gh pr create \
             --base main --head "${pr_branch}" \
             --title "deps(docker-compose): force-bump camunda-${MINOR} component versions" \
             --body "Automated force-bump of \`camunda-${MINOR}\` Docker Compose component versions. Reason: ${REASON}. Authored from caller-supplied versions and merged via the distro CI app to rebuild the rolling \`docker-compose-${MINOR}\` release ahead of Renovate.")"
           echo "Opened ${pr_url}"
 
-          # Distro app approves (distinct identity) then merges with the app token so the push to
-          # main is app-attributed and triggers the rolling release.
-          GH_TOKEN="${APP_TOKEN}" gh pr review "${pr_url}" --approve
+          # GITHUB_TOKEN is the distinct approver for the ruleset's 1-approval rule.
+          gh pr review "${pr_url}" --approve
+          # Fail here rather than stall: nothing else approves this PR, so an ignored bot approval
+          # would leave it open until the caller's own wait expires.
+          for _ in 1 2 3; do
+            decision="$(GH_TOKEN="${APP_TOKEN}" gh pr view "${pr_url}" --json reviewDecision --jq .reviewDecision || true)"
+            [ "${decision}" = "APPROVED" ] && break
+            sleep 5
+          done
+          if [ "${decision}" != "APPROVED" ]; then
+            echo "::error::${pr_url} is ${decision:-unknown}, not APPROVED — check that the repository allows GitHub Actions to approve pull requests."
+            exit 1
+          fi
 
           # Auto-merge instead of immediate merge: the main ruleset's required checks take minutes,
           # so an immediate merge is rejected with "base branch policy prohibits the merge" for the
@@ -164,7 +173,7 @@ jobs:
 
           # Bounded wait for the actual merge so this run's conclusion reflects reality.
           attempt=1
-          max_attempts=20   # 20 x 30s = 10 min, within the job's 15 min timeout
+          max_attempts=60   # 60 x 30s = 30 min, within the job's 45 min timeout
           while :; do
             state="$(GH_TOKEN="${APP_TOKEN}" gh pr view "${pr_url}" --json state --jq .state || true)"
             case "${state}" in


### PR DESCRIPTION
Closes #731.

## Changes

**`docker-compose-force-bump.yaml`** — the distro CI app now owns the branch push and the PR (`checkout` takes the app token, `gh pr create` runs with `GH_TOKEN=${APP_TOKEN}`), so the run actor is `distro-ci[bot]` instead of `github-actions[bot]`. That is the whole defect: GitHub grants `github-actions[bot]`-actored runs no automatic workflow execution, so the checks parked at `action_required` and the completed E2E run emitted no `workflow_run`, leaving `merge-gate.yaml`'s `mirror-e2e` unfired and the required `gate` status pending forever. With the app as actor, checks start immediately and the mirror resolves `gate` as designed.

The approver roles swap: `GITHUB_TOKEN` (`github-actions[bot]`) casts the 1 approval the main ruleset requires, which is a distinct identity from the app that opened the PR and triggers no workflows of its own. Since nothing else approves this PR, the run then asserts `reviewDecision == APPROVED` and fails loudly rather than leaving the PR open until the caller's wait expires. The merge stays app-token-attributed so `docker-compose-release.yaml` still fires.

Merge poll 10 → 30 min against a 15 → 45 min job timeout, so a green-but-slow matrix no longer expires the poll and reports failure on a PR that does merge.

**`renovate-ci-retry.yaml` → `ci-retry.yaml`** — flake retry now also matches `force-compose-bump/` branches, so one flaky E2E job on a force-bump PR is no longer terminal. Renamed with the widened scope.

## Verification

Dispatched this branch's force-bump with `gh workflow run --ref`, patched to open a draft PR against a throwaway base and skip the merge: PR #733 came out authored by `distro-ci[bot]` with its E2E run at `created == started`, `attempt=1` — no `action_required` hold, against 3-for-3 holds (7 min to 3 days) for the `github-actions[bot]` runs. `workflow_run` dispatch for an app-actored run is confirmed by Merge Gate run 32225141636 (`actor=distro-ci[bot]`); across 584 dispatches, zero have `actor=github-actions[bot]`.
