### PR TITLE
feat(camunda-8.10): migrate Identity presets from Web Modeler to Hub

### DIFF
--- a/docker-compose/versions/camunda-8.10/.env
+++ b/docker-compose/versions/camunda-8.10/.env
@@ -50,9 +50,6 @@ ORCHESTRATION_CLIENT_SECRET=secret
 CONNECTORS_CLIENT_ID=connectors
 CONNECTORS_CLIENT_SECRET=demo-connectors-secret
 
-# Console
-CONSOLE_CLIENT_SECRET=demo-console-secret
-
 # Optimize
 OPTIMIZE_CLIENT_SECRET=demo-optimize-secret
 

--- a/docker-compose/versions/camunda-8.10/.identity/application.yaml
+++ b/docker-compose/versions/camunda-8.10/.identity/application.yaml
@@ -106,6 +106,10 @@ identity:
               description: "Admin permission"
             - definition: admin:clusters
               description: "Cluster management permission"
+            - definition: admin:catalog
+              description: "Catalog management permission"
+            - definition: admin:bi
+              description: "Business intelligence management permission"
         - name: Hub API
           audience: "web-modeler-public-api"
           permissions:
@@ -150,6 +154,19 @@ identity:
               definition: write:*
             - audience: "web-modeler-api"
               definition: admin:*
+        - name: "Analyst"
+          description: "Grants full access to Optimize and to Hub. Additionally, grants management access to Hub's catalog and business intelligence features"
+          permissions:
+            - audience: "optimize-api"
+              definition: write:*
+            - audience: "web-modeler-api"
+              definition: write:*
+            - audience: "camunda-identity-resource-server"
+              definition: read:users
+            - audience: "web-modeler-api"
+              definition: admin:catalog
+            - audience: "web-modeler-api"
+              definition: admin:bi
         - name: "Console"
           description: "Grants access to Hub's cluster management"
           permissions:
@@ -205,6 +222,7 @@ keycloak:
         - Hub
         - Hub Admin
         - DevOps
+        - Analyst
         - Orchestration
 
 server:

--- a/docker-compose/versions/camunda-8.10/.identity/application.yaml
+++ b/docker-compose/versions/camunda-8.10/.identity/application.yaml
@@ -18,26 +18,6 @@ identity:
           permissions:
             - audience: "orchestration-api"
               definition: read:*
-    console:
-      applications:
-        - name: "Console"
-          id: console
-          type: public
-          root-url: "http://localhost:8087"
-          redirect-uris:
-            - "/"
-      apis:
-        - name: Console API
-          audience: "console-api"
-          permissions:
-            - definition: write:*
-              description: "Write permission"
-      roles:
-        - name: "Console"
-          description: "Grants full access to Console"
-          permissions:
-            - audience: "console-api"
-              definition: write:*
     identity:
       apis:
         - name: "Camunda Identity Resource Server"
@@ -110,21 +90,23 @@ identity:
               definition: read:users
     webmodeler:
       applications:
-        - name: "Web Modeler"
+        - name: "Hub"
           id: web-modeler
           type: public
           root-url: "http://localhost:8070"
           redirect-uris:
             - "/login-callback"
       apis:
-        - name: Web Modeler Internal API
+        - name: Hub Internal API
           audience: "web-modeler-api"
           permissions:
             - definition: write:*
               description: "Write permission"
             - definition: admin:*
               description: "Admin permission"
-        - name: Web Modeler API
+            - definition: admin:clusters
+              description: "Cluster management permission"
+        - name: Hub API
           audience: "web-modeler-public-api"
           permissions:
             - definition: create:*
@@ -137,14 +119,14 @@ identity:
               description: "Allows delete access for all resources"
       roles:
         - name: "Web Modeler"
-          description: "Grants full access to Web Modeler"
+          description: "Grants full access to Hub"
           permissions:
             - audience: "web-modeler-api"
               definition: write:*
             - audience: "camunda-identity-resource-server"
               definition: read:users
         - name: "Web Modeler Admin"
-          description: "Grants elevated access to Web Modeler"
+          description: "Grants elevated access to Hub"
           permissions:
             - audience: "camunda-identity-resource-server"
               definition: read:users
@@ -152,6 +134,40 @@ identity:
               definition: write:*
             - audience: "web-modeler-api"
               definition: admin:*
+        - name: "Hub"
+          description: "Grants full access to Hub"
+          permissions:
+            - audience: "web-modeler-api"
+              definition: write:*
+            - audience: "camunda-identity-resource-server"
+              definition: read:users
+        - name: "Hub Admin"
+          description: "Grants elevated access to Hub"
+          permissions:
+            - audience: "camunda-identity-resource-server"
+              definition: read:users
+            - audience: "web-modeler-api"
+              definition: write:*
+            - audience: "web-modeler-api"
+              definition: admin:*
+        - name: "Console"
+          description: "Grants access to Hub's cluster management"
+          permissions:
+            - audience: "web-modeler-api"
+              definition: write:*
+            - audience: "camunda-identity-resource-server"
+              definition: read:users
+            - audience: "web-modeler-api"
+              definition: admin:clusters
+        - name: "DevOps"
+          description: "Grants access to Hub's cluster management"
+          permissions:
+            - audience: "web-modeler-api"
+              definition: write:*
+            - audience: "camunda-identity-resource-server"
+              definition: read:users
+            - audience: "web-modeler-api"
+              definition: admin:clusters
 
 keycloak:
   url: "http://${KEYCLOAK_HOST}:18080/auth"
@@ -159,8 +175,6 @@ keycloak:
     user: "${KEYCLOAK_ADMIN_USER:admin}"
     password: "${KEYCLOAK_ADMIN_PASSWORD}"
   init:
-    console:
-      secret: "${CONSOLE_CLIENT_SECRET}"
     orchestration:
       secret: "${ORCHESTRATION_CLIENT_SECRET}"
     optimize:
@@ -188,9 +202,9 @@ keycloak:
       roles:
         - ManagementIdentity
         - Optimize
-        - Web Modeler
-        - Web Modeler Admin
-        - Console
+        - Hub
+        - Hub Admin
+        - DevOps
         - Orchestration
 
 server:


### PR DESCRIPTION
### Related

* Mirrors https://github.com/camunda/identity/pull/4541 (Management Identity built-in presets)
* Relates to https://github.com/camunda/camunda-hub/issues/21467
* Relates to https://github.com/camunda/camunda-hub/issues/25470

### Description

`docker-compose/versions/camunda-8.10/.identity/application.yaml` is mounted at `/app/application.yaml` in the Identity container (both `docker-compose-full.yaml` and `docker-compose-web-modeler.yaml`), so it overrides the presets that ship inside the image. camunda/identity#4541 on its own therefore has no effect on docker-compose installations. This PR applies the same change here.

**Web Modeler labels become Hub.** Display names only: the `webmodeler` preset key, the `web-modeler` client id and the `web-modeler-api` audience are deliberately left alone, matching the upstream PR's backward-compatibility choice.

**Console is folded into Hub.** The standalone `console` client and the `console-api` resource server are removed. Console has not run as its own service in the 8.10 compose files for a while, so this only removes the now-unused Keycloak provisioning. Cluster management moves to a new `admin:clusters` permission on Hub's internal API. The `Console` role is kept and remapped onto that permission so existing role holders keep cluster admin access after upgrading, and a `DevOps` role is added as the equivalent for new installations.

`CONSOLE_CLIENT_SECRET` in `.env` becomes unused and is removed with it.

The demo user gets `Hub`, `Hub Admin` and `DevOps` rather than the legacy `Web Modeler`, `Web Modeler Admin` and `Console` names. A fresh compose install is not an upgrade, and the permission sets behind the two groups of names are identical.

### Is there anything else to consider?

Two leftovers spotted while doing this, deliberately left out to keep the change single-purpose:

* `docker-compose/versions/camunda-8.10/.console/application.yaml` is orphaned. No service mounts it.
* `CAMUNDA_CONSOLE_VERSION` in `.env` is unused. No compose file references the `camunda/console` image.

Happy to fold either or both in if you would rather not leave them.
