### PR TITLE
refactor(docker-compose): rename web modeler play to test mode

### DIFF
--- a/docker-compose/versions/camunda-8.10/.web-modeler/application.yaml
+++ b/docker-compose/versions/camunda-8.10/.web-modeler/application.yaml
@@ -6,7 +6,7 @@ camunda:
     type: KEYCLOAK
   modeler:
     feature:
-      play-enabled: true
+      test-mode-enabled: true
     pusher:
       host: hub-websockets
       port: 8060


### PR DESCRIPTION
Renaming Web Modeler from Play to Test Mode (only for 8.10).
Part of: https://github.com/camunda/team-distribution/issues/839