### PR TITLE
ci(github-actions): key release concurrency per version

### DIFF
--- a/.github/workflows/docker-compose-release-template.yaml
+++ b/.github/workflows/docker-compose-release-template.yaml
@@ -18,6 +18,9 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    concurrency:
+      group: docker-compose-release-${{ inputs.camunda-version }}-${{ github.ref_name }}
+      cancel-in-progress: false
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/docker-compose-release.yaml
+++ b/.github/workflows/docker-compose-release.yaml
@@ -22,7 +22,7 @@ on:
         type: boolean
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Closes #799

`docker-compose-release.yaml` grouped concurrency on the branch, so two pushes to `main` touching different version directories cancelled each other and the survivor never re-cut the killed version.

- Caller group keys on `github.run_id` for push and dispatch, so those runs no longer share a group. Pull request runs still collapse on the PR number.
- `docker-compose-release-template.yaml` gains a per-version job group, which restores the serialisation the caller group used to provide. `cancel-in-progress: false` keeps a publish from being interrupted between `gh release delete` and the recreate; a superseded same-version run is redundant because the job checks out `github.ref`.
