### PR TITLE
ci: key e2e-test concurrency per version to stop cross-version cancellation

### DIFF
--- a/.github/workflows/docker-compose-test-e2e-full-setup.yaml
+++ b/.github/workflows/docker-compose-test-e2e-full-setup.yaml
@@ -13,7 +13,7 @@ on:
       - docker-compose/versions/**
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/docker-compose-test-e2e-template.yaml
+++ b/.github/workflows/docker-compose-test-e2e-template.yaml
@@ -41,6 +41,9 @@ jobs:
     # if: contains(inputs.changed-versions, inputs.camunda-version)
     name: Run
     runs-on: ubuntu-latest
+    concurrency:
+      group: docker-compose-e2e-${{ inputs.camunda-version }}-${{ inputs.main-compose-args }}-${{ github.ref_name }}
+      cancel-in-progress: false
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
       #


### PR DESCRIPTION
Fixes remaining gap from #799, follow-up to #800.

#800 fixed the cross-version concurrency-cancellation bug in `docker-compose-release.yaml`/`-template.yaml`. Review of #800 found `docker-compose-test-e2e-full-setup.yaml` and `docker-compose-test-e2e-template.yaml` still carry the identical branch-keyed concurrency group bug — here it manifests as lost e2e coverage instead of dropped releases.

This PR applies the same fix pattern to those two files:

- Caller group is now keyed on `github.run_id` (not `ref_name`) for push events, so separate workflow runs don't collide with each other.
- The reusable template job gets its own concurrency group keyed on `camunda-version` + `main-compose-args` + `ref_name`, with `cancel-in-progress: false`, so same-version/variant runs queue instead of cancelling each other.