### PR TITLE
fix(hub): add missing admin:clusters permission definition

### DIFF
--- a/docker-compose/versions/camunda-8.10/.identity/application.yaml
+++ b/docker-compose/versions/camunda-8.10/.identity/application.yaml
@@ -109,6 +109,8 @@ identity:
               description: "Write permission"
             - definition: admin:*
               description: "Admin permission"
+            - definition: admin:clusters
+              description: "Cluster management permission"
             - definition: admin:catalog
               description: "Catalog management permission"
             - definition: admin:bi


### PR DESCRIPTION
## Summary
- Adds the `admin:clusters` permission definition (Cluster management permission) to the camunda-8.10 Hub Identity configuration, which was missing alongside the other `admin:*` sub-permissions.

## Test plan
- [ ] Start the camunda-8.10 Hub Compose entry point and verify the `admin:clusters` permission is selectable/assignable in Identity